### PR TITLE
Adds a query and a route to return all stands in geojson and json format

### DIFF
--- a/queries.js
+++ b/queries.js
@@ -156,14 +156,14 @@ function getCadastralData(req, res, next){
   })
 }
 
-function getAvailableStands(req, res, next){
+function getAllStands(req, res, next){
 
   if (req.query.map)
   {
 
-      var availablestandssql = "SELECT 'FeatureCollection' AS type, array_to_json(array_agg(f)) AS features FROM (SELECT 'Feature' AS type, ST_AsGeoJSON(lg.geom, 6)::json As geometry, row_to_json((SELECT l FROM (SELECT dsg_num, cityid, townshipid) AS l)) AS properties FROM cadastre AS lg ) AS f";
+      var allStandsSql = "SELECT 'FeatureCollection' AS type, array_to_json(array_agg(f)) AS features FROM (SELECT 'Feature' AS type, ST_AsGeoJSON(lg.geom, 6)::json As geometry, row_to_json((SELECT l FROM (SELECT dsg_num, cityid, townshipid) AS l)) AS properties FROM cadastre AS lg ) AS f";
 
-      db.any(availablestandssql)
+      db.any(allStandsSql)
       .then(function (data){
         res.status(200)
         .header('Access-Control-Allow-Origin','*')
@@ -181,10 +181,10 @@ function getAvailableStands(req, res, next){
   }
   else
   {
-    var availablestandssql = "SELECT cadastre.dsg_num AS Stand, cities.name AS City, townships.name AS Township FROM cadastre, cities, townships WHERE cadastre.townshipid = townships.townshipid AND cadastre.cityid = cities.cityid";
+    var allStandsSql = "SELECT cadastre.dsg_num AS Stand, cities.name AS City, townships.name AS Township FROM cadastre, cities, townships WHERE cadastre.townshipid = townships.townshipid AND cadastre.cityid = cities.cityid";
     //var leakagequery = "SELECT 'FeatureCollection' AS type, array_to_json(array_agg(f)) AS features FROM (SELECT 'Feature' AS type,   ST_AsGeoJSON(leakages.geom, 6)::json As geometry,    row_to_json((SELECT l FROM (SELECT townships.name AS townshipname,leakages.source AS source, leakages.status AS status, leakages.intensity AS intensity, leakages.datereported as datereported, leakages.recorder as reporter, townships.geom) AS l)) AS properties FROM townships, leakages     WHERE  ST_Within(leakages.geom, townships.geom)   GROUP BY leakages.geom,townships.name ,leakages.source , leakages.status , leakages.intensity,leakages.recorder, leakages.datereported,townships.geom ) AS f";
 
-    db.any(availablestandssql)
+    db.any(allStandsSql)
     .then(function (data){
       res.status(200)
       .header('Access-Control-Allow-Origin','*')
@@ -213,5 +213,5 @@ module.exports = {
   getCitiesData: getCitiesData,
   getReservations: getReservations,
   getCadastralData: getCadastralData,
-  getAvailableStands: getAvailableStands
+  getAllStands: getAllStands
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -51,7 +51,7 @@ router.get('/api/cadastre', db.getCadastralData);
 router.get('/api/reservations', db.getReservations);
 
 // stands api
-router.get('/api/stands/available', db.getAvailableStands);
+router.get('/api/stands/all', db.getAllStands);
 
 
 app.get('/db', function (request, response) {


### PR DESCRIPTION
This is a fix for [issue #4 ](https://github.com/cparadzayi/reims/issues/4). The commit ```6e139e6f6a1cba713cb9d5a540e5e0d4189625cf``` removes some the async module from the node_modules folder because @cparadzayi explicitly instructed git to ignore them. This problem could not be fixed by ```$ npm install`` hence I created a separate branch from the latest working commit and manually added the code to retrieve all stands in geojson and json form without ignoring the async module.